### PR TITLE
Added option to add short community name

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ The template is created by [GDG Jalandhar](https://meetup.com/GDG-Jalandhar/) te
             }
         }
     ```
+1. Go to Firebase Storage
+1. Copy the code which looks similar to the below sample and update the rule for Firebase Storage
+    ```js
+    service firebase.storage {
+      match /b/{bucket}/o {
+        match /{allPaths=**} {
+          allow read, write: if request.auth != null;
+        }
+      }
+    }
+    ```
 1. In the Firebase project console dashboard. Click on create a new app
 1. Go to Firebase project Settings and then General Settings Tab
 1. Scroll down and go to your app section under Firebase SDK snippet

--- a/src/components/Common/ImageUpload.vue
+++ b/src/components/Common/ImageUpload.vue
@@ -17,7 +17,7 @@
           @change="onFileChange"
           outlined
         ></v-file-input>
-        <p class="google-font my-0" style="color:red">*Image should be in jpeg/jpg/png/webp/ico only</p>
+        <p class="google-font my-0" style="color:red">*Image should be in jpeg/jpg/png/webp/ico/svg only</p>
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
@@ -61,8 +61,8 @@ export default {
       let ext = this.imageUpload.name.split(".").pop();
 
       // Checking if Extension us 
-      if(ext != 'jpeg' && ext != 'jpg' && ext != 'png' && ext != "webp" && ext != 'JFIF' && ext != 'ico'){
-        this.$emit("message", "Please choose image format in jpeg/jpg/png/webp/JFIF/ico");
+      if(ext != 'jpeg' && ext != 'jpg' && ext != 'png' && ext != "webp" && ext != 'JFIF' && ext != 'ico' && ext != 'svg'){
+        this.$emit("message", "Please choose image format in jpeg/jpg/png/webp/JFIF/ico/svg");
         this.imageUploading = false;
         return;
       }

--- a/src/components/Config/General/General.vue
+++ b/src/components/Config/General/General.vue
@@ -34,6 +34,12 @@
               ></v-text-field>
               <v-text-field
                 class="my-0 py-0"
+                label="Community Short Name"
+                v-model="communityinfo.shortName"
+                outlined
+              ></v-text-field>
+              <v-text-field
+                class="my-0 py-0"
                 label="Community Email"
                 type="email"
                 v-model="communityinfo.email"
@@ -245,6 +251,7 @@ export default {
     toolbarImage:"",
     communityinfo: {
       name: "",
+      shortName: "",
       email:"",
       website: "",
       meetupLink: "",


### PR DESCRIPTION
It may be used for those Chapters that have long names.
As per usual cases, if the name is too long it will be truncated by periods (that are definitely not nice).

Will edit the UI in future commits for components that can use the short name.