### PR TITLE
Added option to add short community name

### DIFF
--- a/src/components/Config/General/General.vue
+++ b/src/components/Config/General/General.vue
@@ -34,6 +34,12 @@
               ></v-text-field>
               <v-text-field
                 class="my-0 py-0"
+                label="Community Short Name"
+                v-model="communityinfo.shortName"
+                outlined
+              ></v-text-field>
+              <v-text-field
+                class="my-0 py-0"
                 label="Community Email"
                 type="email"
                 v-model="communityinfo.email"
@@ -245,6 +251,7 @@ export default {
     toolbarImage:"",
     communityinfo: {
       name: "",
+      shortName: "",
       email:"",
       website: "",
       meetupLink: "",


### PR DESCRIPTION
It may be used for those Chapters that have long names.
As per usual cases, if the name is too long it will be truncated by periods (that are definitely not nice).