### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The template is created by [GDG Jalandhar](https://meetup.com/GDG-Jalandhar/) te
 1. [Fork this repository](https://github.com/gdg-x/aura-admin/fork) & [Aura Main](https://github.com/Vrijraj/aura/fork) (Important) and clone both repo locally
 1. Setup Environment
    - Install [Node.js (v8.9.4 or above)](https://nodejs.org/en/download/)
-   - Install vue cli: `npm install -g @vue/cli`
+   - Install vue cli: `npm install @vue/cli '--location=global'`
 1. Install project dependencies: `npm install`
 1. If you already have setup [Aura Main](https://github.com/Vrijraj/aura/fork) then use same Firebase Project
 1. Otherwise Create [Firebase account](https://console.firebase.google.com) and Create a new Project


### PR DESCRIPTION
- Updated command to install Vue CLI
- Old Command
`npm install -g @vue/cli`
** This is deprecated in a newer version of Node
- New Command
`npm install @vue/cli '--location=global'`